### PR TITLE
feat: add MiniMax as LLM provider in experimental module

### DIFF
--- a/ChatTTS/experimental/llm.py
+++ b/ChatTTS/experimental/llm.py
@@ -1,6 +1,15 @@
 
 from openai import OpenAI
- 
+
+# MiniMax API constants
+MINIMAX_BASE_URL = "https://api.minimax.io/v1"
+MINIMAX_MODELS = [
+    "MiniMax-M2.7",
+    "MiniMax-M2.7-highspeed",
+    "MiniMax-M2.5",
+    "MiniMax-M2.5-highspeed",
+]
+
 prompt_dict = {
     'kimi': [ {"role": "system", "content": "你是 Kimi，由 Moonshot AI 提供的人工智能助手，你更擅长中文和英文的对话。"},
               {"role": "user", "content": "你好，请注意你现在生成的文字要按照人日常生活的口吻，你的回复将会后续用TTS模型转为语音，并且请把回答控制在100字以内。并且标点符号仅包含逗号和句号，将数字等转为文字回答。"},
@@ -20,8 +29,24 @@ prompt_dict = {
         {"role": "user", "content": "罗森宣布将于7月24日退市，在华门店超6000家！"},
         {"role": "assistant", "content": "罗森宣布将于七月二十四日退市，在华门店超过六千家。"},
         ],
-}          
-                
+    'minimax': [
+        {"role": "system", "content": "You are a helpful assistant provided by MiniMax."},
+        {"role": "user", "content": "你好，请注意你现在生成的文字要按照人日常生活的口吻，你的回复将会后续用TTS模型转为语音，并且请把回答控制在100字以内。并且标点符号仅包含逗号和句号，将数字等转为文字回答。"},
+        {"role": "assistant", "content": "好的，我现在生成的文字将按照人日常生活的口吻，并且我会把回答控制在一百字以内，标点符号仅包含逗号和句号，将阿拉伯数字等转为中文文字回答。下面请开始对话。"},
+    ],
+    'minimax_TN': [
+        {"role": "system", "content": "You are a helpful assistant provided by MiniMax."},
+        {"role": "user", "content": "你好，现在我们在处理TTS的文本输入，下面将会给你输入一段文本，请你将其中的阿拉伯数字等等转为文字表达，并且输出的文本里仅包含逗号和句号这两个标点符号"},
+        {"role": "assistant", "content": "好的，我现在对TTS的文本输入进行处理。这一般叫做text normalization。下面请输入"},
+        {"role": "user", "content": "We paid $123 for this desk."},
+        {"role": "assistant", "content": "We paid one hundred and twenty three dollars for this desk."},
+        {"role": "user", "content": "详询请拨打010-724654"},
+        {"role": "assistant", "content": "详询请拨打零幺零，七二四六五四"},
+        {"role": "user", "content": "罗森宣布将于7月24日退市，在华门店超6000家！"},
+        {"role": "assistant", "content": "罗森宣布将于七月二十四日退市，在华门店超过六千家。"},
+    ],
+}
+
 class llm_api:
     def __init__(self, api_key, base_url, model):
         self.client =  OpenAI(
@@ -30,7 +55,10 @@ class llm_api:
         )
         self.model = model
     def call(self, user_question, temperature = 0.3, prompt_version='kimi', **kwargs):
-    
+        # MiniMax requires temperature > 0
+        if temperature <= 0:
+            temperature = 0.01
+
         completion = self.client.chat.completions.create(
             model = self.model,
             messages = prompt_dict[prompt_version]+[{"role": "user", "content": user_question},],
@@ -38,3 +66,27 @@ class llm_api:
             **kwargs
         )
         return completion.choices[0].message.content
+
+
+def create_minimax_client(api_key: str, model: str = "MiniMax-M2.7") -> llm_api:
+    """Create an llm_api client pre-configured for MiniMax.
+
+    Args:
+        api_key: MiniMax API key (set MINIMAX_API_KEY env var or pass directly).
+        model: MiniMax model name. Defaults to MiniMax-M2.7 (204K context).
+               Other options: MiniMax-M2.7-highspeed, MiniMax-M2.5, MiniMax-M2.5-highspeed.
+
+    Returns:
+        llm_api instance ready to use with prompt_version='minimax' or 'minimax_TN'.
+
+    Example::
+
+        import os
+        from ChatTTS.experimental.llm import create_minimax_client
+
+        client = create_minimax_client(os.environ["MINIMAX_API_KEY"])
+        reply = client.call("What is the weather today?", prompt_version="minimax")
+    """
+    if model not in MINIMAX_MODELS:
+        raise ValueError(f"Unknown MiniMax model '{model}'. Choose from: {MINIMAX_MODELS}")
+    return llm_api(api_key=api_key, base_url=MINIMAX_BASE_URL, model=model)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,34 @@ Enhance the authenticity of speech by utilizing ChatTTS for more natural voice g
 Have a try on huggingface!
 https://huggingface.co/spaces/Hilley/ChatTTS-OpenVoice
 
+---
+__Experimental LLM Integration__
+
+`ChatTTS/experimental/llm.py` provides an OpenAI-compatible LLM API wrapper for text pre-processing (e.g. text normalisation before TTS inference). Supported providers:
+
+| Provider | `base_url` | Prompt versions |
+|----------|-----------|----------------|
+| Kimi (Moonshot AI) | `https://api.moonshot.cn/v1` | `kimi` |
+| DeepSeek | `https://api.deepseek.com/v1` | `deepseek`, `deepseek_TN` |
+| **MiniMax** | `https://api.minimax.io/v1` | `minimax`, `minimax_TN` |
+
+**MiniMax quick start** (models: `MiniMax-M2.7`, `MiniMax-M2.7-highspeed`, `MiniMax-M2.5`, `MiniMax-M2.5-highspeed`; all with 204K context):
+
+```python
+import os
+from ChatTTS.experimental.llm import create_minimax_client
+
+client = create_minimax_client(os.environ["MINIMAX_API_KEY"])
+
+# Conversational reply (TTS-friendly tone, ≤100 chars)
+reply = client.call("今天北京天气怎么样？", prompt_version="minimax")
+
+# Text normalisation before TTS
+normalized = client.call("We paid $123 for this desk.", prompt_version="minimax_TN")
+```
+
+Get a MiniMax API key at https://www.minimaxi.com/
+
 <img width="1792" alt="image" src="https://github.com/HKoon/ChatTTS-OpenVoice/assets/24382626/9d9592f1-b527-4c7a-b7f8-caf2cd25bc1d">
 
 

--- a/tests/test_minimax_llm.py
+++ b/tests/test_minimax_llm.py
@@ -1,0 +1,233 @@
+"""Unit tests for MiniMax LLM provider in ChatTTS/experimental/llm.py."""
+
+import importlib
+import importlib.util
+import os
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Stub heavy dependencies so the module can be imported without GPU/torch/vocos
+# ---------------------------------------------------------------------------
+def _stub(name):
+    mod = types.ModuleType(name)
+    sys.modules[name] = mod
+    return mod
+
+
+for _name in [
+    "vocos", "torch", "torchaudio", "torchvision",
+    "transformers", "omegaconf", "vector_quantize_pytorch",
+    "huggingface_hub", "ChatTTS.core", "ChatTTS.model",
+    "ChatTTS.model.dvae", "ChatTTS.model.gpt",
+    "ChatTTS.utils", "ChatTTS.utils.gpu_utils",
+    "ChatTTS.utils.infer_utils", "ChatTTS.utils.io_utils",
+    "ChatTTS.infer", "ChatTTS.infer.api",
+]:
+    if _name not in sys.modules:
+        _stub(_name)
+
+# Provide a minimal OpenAI stub
+if "openai" not in sys.modules:
+    _stub("openai")
+
+
+class _FakeChoice:
+    def __init__(self, content):
+        self.message = MagicMock(content=content)
+
+
+class _FakeCompletion:
+    def __init__(self, content):
+        self.choices = [_FakeChoice(content)]
+
+
+class _FakeChatCompletions:
+    def create(self, **kwargs):
+        return _FakeCompletion("mock response")
+
+
+class _FakeChat:
+    completions = _FakeChatCompletions()
+
+
+class _FakeOpenAI:
+    def __init__(self, api_key=None, base_url=None):
+        self.api_key = api_key
+        self.base_url = base_url
+        self.chat = _FakeChat()
+
+
+sys.modules["openai"].OpenAI = _FakeOpenAI
+
+# Patch ChatTTS __init__ to avoid importing core
+chattts_pkg = types.ModuleType("ChatTTS")
+chattts_pkg.__path__ = [os.path.join(os.path.dirname(__file__), "..", "ChatTTS")]
+chattts_pkg.__package__ = "ChatTTS"
+sys.modules["ChatTTS"] = chattts_pkg
+
+# Load the experimental sub-package
+exp_pkg = types.ModuleType("ChatTTS.experimental")
+exp_pkg.__path__ = [os.path.join(os.path.dirname(__file__), "..", "ChatTTS", "experimental")]
+exp_pkg.__package__ = "ChatTTS.experimental"
+sys.modules["ChatTTS.experimental"] = exp_pkg
+
+# Now import the module under test directly via spec
+_llm_path = os.path.join(os.path.dirname(__file__), "..", "ChatTTS", "experimental", "llm.py")
+_spec = importlib.util.spec_from_file_location("ChatTTS.experimental.llm", _llm_path)
+_llm_mod = importlib.util.module_from_spec(_spec)
+sys.modules["ChatTTS.experimental.llm"] = _llm_mod
+_spec.loader.exec_module(_llm_mod)
+
+MINIMAX_BASE_URL = _llm_mod.MINIMAX_BASE_URL
+MINIMAX_MODELS = _llm_mod.MINIMAX_MODELS
+create_minimax_client = _llm_mod.create_minimax_client
+llm_api = _llm_mod.llm_api
+prompt_dict = _llm_mod.prompt_dict
+
+
+class TestMinimaxConstants(unittest.TestCase):
+    def test_base_url(self):
+        self.assertEqual(MINIMAX_BASE_URL, "https://api.minimax.io/v1")
+
+    def test_models_list(self):
+        self.assertIn("MiniMax-M2.7", MINIMAX_MODELS)
+        self.assertIn("MiniMax-M2.7-highspeed", MINIMAX_MODELS)
+        self.assertIn("MiniMax-M2.5", MINIMAX_MODELS)
+        self.assertIn("MiniMax-M2.5-highspeed", MINIMAX_MODELS)
+        self.assertEqual(len(MINIMAX_MODELS), 4)
+
+
+class TestPromptDict(unittest.TestCase):
+    def test_minimax_prompt_exists(self):
+        self.assertIn("minimax", prompt_dict)
+
+    def test_minimax_tn_prompt_exists(self):
+        self.assertIn("minimax_TN", prompt_dict)
+
+    def test_minimax_prompt_has_system_role(self):
+        roles = [m["role"] for m in prompt_dict["minimax"]]
+        self.assertIn("system", roles)
+
+    def test_minimax_tn_contains_number_example(self):
+        contents = [m["content"] for m in prompt_dict["minimax_TN"]]
+        self.assertTrue(any("$123" in c for c in contents))
+
+    def test_existing_prompts_unchanged(self):
+        self.assertIn("kimi", prompt_dict)
+        self.assertIn("deepseek", prompt_dict)
+        self.assertIn("deepseek_TN", prompt_dict)
+
+
+class TestLlmApiTemperatureClamping(unittest.TestCase):
+    """MiniMax requires temperature > 0; zero should be clamped."""
+
+    def _make_client(self):
+        return llm_api(
+            api_key="test_key",
+            base_url=MINIMAX_BASE_URL,
+            model="MiniMax-M2.7",
+        )
+
+    def test_zero_temperature_clamped(self):
+        client = self._make_client()
+        captured = {}
+
+        def fake_create(**kwargs):
+            captured.update(kwargs)
+            return _FakeCompletion("ok")
+
+        client.client.chat.completions.create = fake_create
+        client.call("hello", temperature=0.0, prompt_version="minimax")
+        self.assertGreater(captured["temperature"], 0)
+
+    def test_positive_temperature_unchanged(self):
+        client = self._make_client()
+        captured = {}
+
+        def fake_create(**kwargs):
+            captured.update(kwargs)
+            return _FakeCompletion("ok")
+
+        client.client.chat.completions.create = fake_create
+        client.call("hello", temperature=0.5, prompt_version="minimax")
+        self.assertEqual(captured["temperature"], 0.5)
+
+    def test_call_returns_string(self):
+        client = self._make_client()
+        result = client.call("hello", prompt_version="minimax")
+        self.assertIsInstance(result, str)
+
+
+class TestCreateMinimaxClient(unittest.TestCase):
+    def test_returns_llm_api_instance(self):
+        client = create_minimax_client("test_key")
+        self.assertIsInstance(client, llm_api)
+
+    def test_default_model(self):
+        client = create_minimax_client("test_key")
+        self.assertEqual(client.model, "MiniMax-M2.7")
+
+    def test_custom_model(self):
+        client = create_minimax_client("test_key", model="MiniMax-M2.5-highspeed")
+        self.assertEqual(client.model, "MiniMax-M2.5-highspeed")
+
+    def test_invalid_model_raises(self):
+        with self.assertRaises(ValueError):
+            create_minimax_client("test_key", model="gpt-4o")
+
+    def test_base_url_set(self):
+        client = create_minimax_client("test_key")
+        self.assertEqual(client.client.base_url, MINIMAX_BASE_URL)
+
+    def test_api_key_passed(self):
+        client = create_minimax_client("my_secret_key")
+        self.assertEqual(client.client.api_key, "my_secret_key")
+
+
+class TestIntegrationMinimax(unittest.TestCase):
+    """Integration-style test: end-to-end call flow without a real API."""
+
+    def test_minimax_call_uses_correct_prompt(self):
+        client = create_minimax_client("test_key")
+        captured = {}
+
+        def fake_create(**kwargs):
+            captured.update(kwargs)
+            return _FakeCompletion("integrated response")
+
+        client.client.chat.completions.create = fake_create
+        result = client.call("Tell me a joke.", prompt_version="minimax")
+
+        self.assertEqual(result, "integrated response")
+        self.assertEqual(captured["model"], "MiniMax-M2.7")
+        messages = captured["messages"]
+        self.assertEqual(messages[-1]["content"], "Tell me a joke.")
+        self.assertEqual(messages[0]["role"], "system")
+
+    def test_minimax_tn_call(self):
+        client = create_minimax_client("test_key", model="MiniMax-M2.7-highspeed")
+        captured = {}
+
+        def fake_create(**kwargs):
+            captured.update(kwargs)
+            return _FakeCompletion("normalized text")
+
+        client.client.chat.completions.create = fake_create
+        result = client.call("We paid $456 for this chair.", prompt_version="minimax_TN")
+        self.assertEqual(result, "normalized text")
+        self.assertEqual(captured["model"], "MiniMax-M2.7-highspeed")
+
+    def test_minimax_env_key(self):
+        """create_minimax_client should accept key from env variable pattern."""
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "env_key"}):
+            key = os.environ["MINIMAX_API_KEY"]
+            client = create_minimax_client(key)
+            self.assertEqual(client.client.api_key, "env_key")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds [MiniMax](https://www.minimaxi.com/) as a fully supported LLM provider inside `ChatTTS/experimental/llm.py`.

- **New prompt presets**: `minimax` (conversational, TTS-friendly) and `minimax_TN` (text normalisation)
- **Constants**: `MINIMAX_BASE_URL = "https://api.minimax.io/v1"` and `MINIMAX_MODELS` list (M2.7, M2.7-highspeed, M2.5, M2.5-highspeed — all 204K context)
- **`create_minimax_client(api_key, model="MiniMax-M2.7")`** factory for one-liner setup with model validation
- **Temperature clamping**: `temperature` is clamped to `>0` in `llm_api.call()` to satisfy MiniMax API constraints
- **README**: provider comparison table + quick-start code example
- **Tests**: 19 unit + integration tests (no GPU/vocos required)

## Usage

```python
import os
from ChatTTS.experimental.llm import create_minimax_client

client = create_minimax_client(os.environ["MINIMAX_API_KEY"])
reply = client.call("今天北京天气怎么样？", prompt_version="minimax")
normalized = client.call("We paid $123 for this desk.", prompt_version="minimax_TN")
```

## Test plan

- [x] `python -m pytest tests/test_minimax_llm.py -v` — 19 passed
- [x] Constants match MiniMax API docs (base URL, model IDs, 204K context)
- [x] Temperature clamping verified for zero-value edge case
- [x] Existing `kimi`/`deepseek` prompts unchanged