### PR TITLE
feat(llm): upgrade MiniMax models to M3

### DIFF
--- a/ChatTTS/experimental/llm.py
+++ b/ChatTTS/experimental/llm.py
@@ -4,10 +4,9 @@ from openai import OpenAI
 # MiniMax API constants
 MINIMAX_BASE_URL = "https://api.minimax.io/v1"
 MINIMAX_MODELS = [
+    "MiniMax-M3",
     "MiniMax-M2.7",
     "MiniMax-M2.7-highspeed",
-    "MiniMax-M2.5",
-    "MiniMax-M2.5-highspeed",
 ]
 
 prompt_dict = {
@@ -68,13 +67,13 @@ class llm_api:
         return completion.choices[0].message.content
 
 
-def create_minimax_client(api_key: str, model: str = "MiniMax-M2.7") -> llm_api:
+def create_minimax_client(api_key: str, model: str = "MiniMax-M3") -> llm_api:
     """Create an llm_api client pre-configured for MiniMax.
 
     Args:
         api_key: MiniMax API key (set MINIMAX_API_KEY env var or pass directly).
-        model: MiniMax model name. Defaults to MiniMax-M2.7 (204K context).
-               Other options: MiniMax-M2.7-highspeed, MiniMax-M2.5, MiniMax-M2.5-highspeed.
+        model: MiniMax model name. Defaults to MiniMax-M3 (latest flagship, 204K context).
+               Other options: MiniMax-M2.7, MiniMax-M2.7-highspeed.
 
     Returns:
         llm_api instance ready to use with prompt_version='minimax' or 'minimax_TN'.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ __Experimental LLM Integration__
 | DeepSeek | `https://api.deepseek.com/v1` | `deepseek`, `deepseek_TN` |
 | **MiniMax** | `https://api.minimax.io/v1` | `minimax`, `minimax_TN` |
 
-**MiniMax quick start** (models: `MiniMax-M2.7`, `MiniMax-M2.7-highspeed`, `MiniMax-M2.5`, `MiniMax-M2.5-highspeed`; all with 204K context):
+**MiniMax quick start** (models: `MiniMax-M3`, `MiniMax-M2.7`, `MiniMax-M2.7-highspeed`; all with 204K context):
 
 ```python
 import os

--- a/tests/test_minimax_llm.py
+++ b/tests/test_minimax_llm.py
@@ -94,11 +94,17 @@ class TestMinimaxConstants(unittest.TestCase):
         self.assertEqual(MINIMAX_BASE_URL, "https://api.minimax.io/v1")
 
     def test_models_list(self):
+        self.assertIn("MiniMax-M3", MINIMAX_MODELS)
         self.assertIn("MiniMax-M2.7", MINIMAX_MODELS)
         self.assertIn("MiniMax-M2.7-highspeed", MINIMAX_MODELS)
-        self.assertIn("MiniMax-M2.5", MINIMAX_MODELS)
-        self.assertIn("MiniMax-M2.5-highspeed", MINIMAX_MODELS)
-        self.assertEqual(len(MINIMAX_MODELS), 4)
+        self.assertEqual(len(MINIMAX_MODELS), 3)
+
+    def test_m3_is_first(self):
+        self.assertEqual(MINIMAX_MODELS[0], "MiniMax-M3")
+
+    def test_legacy_models_removed(self):
+        for legacy in ("MiniMax-M2.5", "MiniMax-M2.5-highspeed", "MiniMax-M2.1", "MiniMax-M2", "MiniMax-M1"):
+            self.assertNotIn(legacy, MINIMAX_MODELS)
 
 
 class TestPromptDict(unittest.TestCase):
@@ -129,7 +135,7 @@ class TestLlmApiTemperatureClamping(unittest.TestCase):
         return llm_api(
             api_key="test_key",
             base_url=MINIMAX_BASE_URL,
-            model="MiniMax-M2.7",
+            model="MiniMax-M3",
         )
 
     def test_zero_temperature_clamped(self):
@@ -169,11 +175,11 @@ class TestCreateMinimaxClient(unittest.TestCase):
 
     def test_default_model(self):
         client = create_minimax_client("test_key")
-        self.assertEqual(client.model, "MiniMax-M2.7")
+        self.assertEqual(client.model, "MiniMax-M3")
 
     def test_custom_model(self):
-        client = create_minimax_client("test_key", model="MiniMax-M2.5-highspeed")
-        self.assertEqual(client.model, "MiniMax-M2.5-highspeed")
+        client = create_minimax_client("test_key", model="MiniMax-M2.7-highspeed")
+        self.assertEqual(client.model, "MiniMax-M2.7-highspeed")
 
     def test_invalid_model_raises(self):
         with self.assertRaises(ValueError):
@@ -203,7 +209,7 @@ class TestIntegrationMinimax(unittest.TestCase):
         result = client.call("Tell me a joke.", prompt_version="minimax")
 
         self.assertEqual(result, "integrated response")
-        self.assertEqual(captured["model"], "MiniMax-M2.7")
+        self.assertEqual(captured["model"], "MiniMax-M3")
         messages = captured["messages"]
         self.assertEqual(messages[-1]["content"], "Tell me a joke.")
         self.assertEqual(messages[0]["role"], "system")


### PR DESCRIPTION
## Summary

Refreshes the MiniMax model list in `ChatTTS/experimental/llm.py` so the experimental LLM wrapper uses the latest generation:

- Add `MiniMax-M3` and set it as the new default for `create_minimax_client(...)`.
- Keep `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as backward-compatible options.
- Drop the older `MiniMax-M2.5` / `MiniMax-M2.5-highspeed` (superseded by M2.7+).
- README quick-start table updated to match.

## Why

`MiniMax-M3` is the current flagship model on the MiniMax open platform. Existing callers that pass `prompt_version="minimax"` / `"minimax_TN"` will now hit M3 by default while still being able to opt into M2.7 / M2.7-highspeed if they want the previous generation.

No API URL or other provider config is touched; this is a model-name-only change.

## Test plan

- `python3 -m unittest discover -s tests` -> 21 / 21 pass.
- Existing tests updated to assert the new default model and the trimmed model list; added two new assertions (`M3 first`, legacy IDs removed).